### PR TITLE
Minor Fixes

### DIFF
--- a/03_Propositions_and_Proofs.org
+++ b/03_Propositions_and_Proofs.org
@@ -4,8 +4,8 @@
 * Propositions and Proofs
 
 By now, you have seen how to define some elementary notions in
-dependent type theory. 
-# TODO: this hasn't been done yet. 
+dependent type theory.
+# TODO: this hasn't been done yet.
 # You have also seen that it is
 # possible to import objects that are defined in Lean's library.
 In this chapter, we will explain how mathematical propositions and
@@ -231,7 +231,7 @@ defined. This makes it possible to process and check theorems in
 parallel, since theorems later in a file do not make use of the
 contents of earlier proofs.
 
-# TODO: it looks like right now, parallel compilation is disabled in 
+# TODO: it looks like right now, parallel compilation is disabled in
 # Lean 3.
 
 # As with definitions, the =print= command will show you the proof of a
@@ -531,7 +531,7 @@ respectively. Alternatively, you can use ASCII equivalents =(|= and =|)=:
 variables p q : Prop
 premises  (hp : p) (hq : q)
 
-example : p ∧ q := (|hp, hq|) 
+example : p ∧ q := (|hp, hq|)
 #+END_SRC
 
 Lean provides another useful syntactic gadget. Given an expression =e=
@@ -766,7 +766,7 @@ example : q ∧ p := iff.mp (and_swap p q) h
 Because =iff= is defined internally from =and=, we can use the
 anonymous constructor notation to construct a proof of =p ↔ q= from
 proofs of the forward and backward directions. We can also use the
-=.^= notation wit =mp= and =mpr=. The previous examples can therefore
+=.^= notation with =mp= and =mpr=. The previous examples can therefore
 be written concisely as follows:
 #+BEGIN_SRC lean
 variables p q : Prop
@@ -804,13 +804,13 @@ leading to the final goal.
 Lean also supports a structured way of reasoning backwards from a
 goal, which models the "suffices to show" construction in ordinary
 mathematics. The next example simply permutes that last two lines in
-the previous proof. 
+the previous proof.
 #+BEGIN_SRC lean
 variables p q : Prop
 
 example (h : p ∧ q) : q ∧ p :=
 have hp : p, from and.left h,
-suffices hq : q, from and.intro hq hp, 
+suffices hq : q, from and.intro hq hp,
 show q, from and.right h
 #+END_SRC
 Writing =suffices hq : q= leaves us with two goals. First, we have to

--- a/04_Quantifiers_and_Equality.org
+++ b/04_Quantifiers_and_Equality.org
@@ -91,7 +91,7 @@ show p z, from and.elim_left (h z)
 -- END
 #+END_SRC
 
-αs another example, here is how we can express the fact that a
+As another example, here is how we can express the fact that a
 relation, =r=, is transitive:
 #+BEGIN_SRC lean
 variables (α : Type) (r : α → α → Prop)
@@ -213,10 +213,10 @@ problematic.
 
 Let us now turn to one of the most fundamental relations defined in
 Lean's library, namely, the equality relation. In a later chapter,
-# TODO: add reference, Chapter [[file:06_Inductive_Types.org::#Inductive_Types][Inductive Types]] 
 we will explain /how/ equality is defined from the primitives of
 Lean's logical framework. In the meanwhile, here we explain how to use
 it.
+# TODO: add reference, Chapter [[file:06_Inductive_Types.org::#Inductive_Types][Inductive Types]]
 
 Of course, a fundamental property of equality is that it is an
 equivalence relation:
@@ -293,7 +293,7 @@ example (α : Type) (a b : α) (P : α → Prop) (h1 : a = b) (h2 : P a) : P b :
 h1 ▸ h2
 #+END_SRC
 The triangle in the second presentation is nothing more than notation
-for =eq.subst=, and you can enter it by typing =\t=. 
+for =eq.subst=, and you can enter it by typing =\t=.
 
 The rule =eq.subst= is used to define the following auxiliary rules,
 which carry out more explicit substitutions. They are designed to deal
@@ -318,7 +318,7 @@ example : f a = g b := congr h₂ h₁
 Lean's library contains a large number of common identities, such as
 these:
 #+BEGIN_SRC lean
-variables (α : Type) [comm_ring α] 
+variables (α : Type) [comm_ring α]
 variables a b c d : α
 
 example : a + 0 = a := add_zero a
@@ -347,7 +347,7 @@ in the natural numbers that uses substitution combined with
 associativity, commutativity, and distributivity of the natural
 numbers.
 #+BEGIN_SRC lean
-variables x y z : ℕ 
+variables x y z : ℕ
 
 example (x y z : ℕ) : x * (y + z) = x * y + x * z := mul_add x y z
 example (x y z : ℕ) : x * (y + z) = x * y + x * z := mul_add x y z
@@ -447,9 +447,9 @@ include h1 h2 h3 h4
 -- BEGIN
 theorem T : a = e :=
 calc
-  a     = d + 1   : by rw [h1, h2, h3]
+  a     = d + 1  : by rw [h1, h2, h3]
     ... = 1 + d  : by rw add_comm
-     ... =  e     : by rw h4
+    ... =  e     : by rw h4
 -- END
 #+END_SRC
 Or even this:
@@ -601,7 +601,7 @@ the existence of any such =x=. Here is an example:
 variables (α : Type) (p q : α → Prop)
 
 example (h : ∃ x, p x ∧ q x) : ∃ x, q x ∧ p x :=
-exists.elim h 
+exists.elim h
   (take w,
     assume hw : p w ∧ q w,
     show ∃ x, q x ∧ p x, from ⟨w, hw^.right, hw^.left⟩)
@@ -694,7 +694,7 @@ match h1, h2 with
 | ⟨w1, hw1⟩, ⟨w2, hw2⟩ := ⟨w1 + w2, by rw [hw1, hw2, mul_add]⟩
 end
 -- END
-#+END_SRC 
+#+END_SRC
 
 # TODO: discuss obtains here when available
 
@@ -829,7 +829,7 @@ structure of informal mathematical proofs. In this section, we discuss
 some additional features of the proof language that are often
 convenient.
 
-# , and =obtain= 
+# , and =obtain=
 
 To start with, we can use anonymous "have" expressions to introduce an
 auxiliary goal without having to label it. We can refer to the last
@@ -896,7 +896,7 @@ example : f 0 ≤ f 3 :=
 have f 0 ≤ f 1, from h 0,
 have f 1 ≤ f 2, from h 1,
 have f 2 ≤ f 3, from h 2,
-show f 0 ≤ f 3, from le_trans ‹f 0 ≤ f 1› 
+show f 0 ≤ f 3, from le_trans ‹f 0 ≤ f 1›
                        (le_trans ‹f 1 ≤ f 2› ‹f 2 ≤ f 3›)
 -- END
 #+END_SRC
@@ -905,7 +905,7 @@ to refer to /anything/ in the context, not just things that were
 introduced anonymously. It use is also not limited to propositions,
 though using it for data is somewhat odd:
 #+BEGIN_SRC lean
-example (n : ℕ) : ℕ := ‹ℕ› 
+example (n : ℕ) : ℕ := ‹ℕ›
 #+END_SRC
 
 The =suppose= keyword acts as an anonymous assume:
@@ -924,7 +924,7 @@ a label, but if you do not wish to name the assumption, you must use
 =suppose= rather than =assume=. The reason is that Lean allows us to
 write =assume h= to introduce a hypothesis without specifying it,
 leaving it to the system to infer to relevant assumption. An anonymous
-=assume= would thus lead to ambiguities when parsing expressions. 
+=assume= would thus lead to ambiguities when parsing expressions.
 
 As with the anonymous =have=, when you use =suppose= to introduce an
 assumption, that assumption can also be invoked later in the proof by
@@ -954,7 +954,7 @@ then =a = b=, and =a ≥ b= is definitionally equal to =b ≤ a=.
 # #+BEGIN_SRC lean
 # import data.nat
 # open nat
-  
+
 # theorem sqrt_two_irrational {a b : ℕ} (co : coprime a b) : a^2 ≠ 2 * b^2 :=
 # assume h : a^2 = 2 * b^2,
 # have even (a^2),
@@ -979,7 +979,7 @@ then =a = b=, and =a ≥ b= is definitionally equal to =b ≤ a=.
 # #+END_SRC
 
 # A previously used example is found below. We had to reject it because
-# we cannot currently include primes.lean in the web version of Lean. 
+# we cannot currently include primes.lean in the web version of Lean.
 # See the discussion at https://github.com/leanprover/tutorial/issues/138.
 #
 # The following proof that there are infinitely many primes is a slight

--- a/04_Quantifiers_and_Equality.org
+++ b/04_Quantifiers_and_Equality.org
@@ -672,7 +672,7 @@ assume ⟨w, hpw, hqw⟩, ⟨w, hqw, hpw⟩
 In the following example, we define =even a= as =∃ b, a = 2*b=, and
 then we show that the sum of two even numbers is an even number.
 #+BEGIN_SRC lean
-definition is_even (a : nat) := ∃ b, a = 2 * b
+def is_even (a : nat) := ∃ b, a = 2 * b
 
 theorem even_plus_even {a b : nat} (h1 : is_even a) (h2 : is_even b) : is_even (a + b) :=
 exists.elim h1 (take w1, assume hw1 : a = 2 * w1,
@@ -686,7 +686,7 @@ Using the various gadgets described in this chapter --- the match
 statement, anonymous constructors, and the =rewrite= tactic, we can
 write this proof concisely as follows:
 #+BEGIN_SRC lean
-definition is_even (a : nat) := ∃ b, a = 2 * b
+def is_even (a : nat) := ∃ b, a = 2 * b
 
 -- BEGIN
 theorem even_plus_even {a b : nat} (h1 : is_even a) (h2 : is_even b) : is_even (a + b) :=

--- a/05_Tactics.org
+++ b/05_Tactics.org
@@ -175,7 +175,7 @@ end
 #+END_SRC
 The =include= command tells Lean to include the indicated variables
 (as well as any variables they depend on) from that point on, until
-the end of the section or file. The limit the effect of an =include=,
+the end of the section or file. To limit the effect of an =include=,
 you can use the =omit= command afterwards:
 #+BEGIN_SRC lean
 variables {p q : Prop} (hp : p) (hq : q)
@@ -497,7 +497,7 @@ begin
   -- case hp : p
   right, exact hp,
   -- case hq : q
-  left, exact hq 
+  left, exact hq
 end
 #+END_SRC
 After =cases h= is applied, there are two goals. In the first, the
@@ -528,7 +528,7 @@ begin
      right, constructor, repeat { assumption },
   intro h,
     cases h with hpq hpr,
-      cases hpq with hp hq, 
+      cases hpq with hp hq,
         constructor, exact hp, left, exact hq,
       cases hpr with hp hr,
         constructor, exact hp, right, exact hr
@@ -546,7 +546,7 @@ example (p q : ℕ → Prop) : (∃ x, p x) → ∃ x, p x ∨ q x :=
 begin
   intro h,
   cases h with x px,
-  constructor, left, exact px 
+  constructor, left, exact px
 end
 #+END_SRC
 Here, the =constructor= tactic leaves the first component of the
@@ -561,7 +561,7 @@ example (p q : ℕ → Prop) : (∃ x, p x) → ∃ x, p x ∨ q x :=
 begin
   intro h,
   cases h with x px,
-  existsi x, left, exact px 
+  existsi x, left, exact px
 end
 #+END_SRC
 
@@ -642,18 +642,18 @@ begin
   apply iff.intro,
     intro h,
     cases h^.right with hq hr,
-      exact 
-        show (p ∧ q) ∨ (p ∧ r), 
+      exact
+        show (p ∧ q) ∨ (p ∧ r),
           from or.inl ⟨h^.left, hq⟩,
-    exact 
-      show (p ∧ q) ∨ (p ∧ r), 
+    exact
+      show (p ∧ q) ∨ (p ∧ r),
         from or.inr ⟨h^.left, hr⟩,
   intro h,
   cases h with hpq hpr,
-    exact 
-      show p ∧ (q ∨ r), 
+    exact
+      show p ∧ (q ∨ r),
         from ⟨hpq^.left, or.inl hpq^.right⟩,
-  exact show p ∧ (q ∨ r), 
+  exact show p ∧ (q ∨ r),
     from ⟨hpr^.left, or.inr hpr^.right⟩
 end
 #+END_SRC
@@ -674,9 +674,9 @@ begin
       from or.inr ⟨h^.left, hr⟩,
   intro h,
   cases h with hpq hpr,
-    show p ∧ (q ∨ r), 
+    show p ∧ (q ∨ r),
       from ⟨hpq^.left, or.inl hpq^.right⟩,
-  show p ∧ (q ∨ r), 
+  show p ∧ (q ∨ r),
     from ⟨hpr^.left, or.inr hpr^.right⟩
 end
 #+END_SRC
@@ -686,7 +686,7 @@ mechanisms discussed below to make it clear where a proof term ends.
 The convention we have used for indentation will be explained momentarily.
 
 In the same way, in a tactic block, Lean interprets =have p, from t₁,
-t₂= as as an abbreviation for =exact (have p, from t₁, t₂)=. Thus the
+t₂= as an abbreviation for =exact (have p, from t₁, t₂)=. Thus the
 first example in this section could have been written more concisely
 as follows:
 #+BEGIN_SRC lean
@@ -738,7 +738,7 @@ leaves more than one subgoal. You can check (using =C-c C-g= in Emacs
 mode, for example) that every line in this proof, there is only one
 goal visible. Notice that you still need to use a comma after a
 =begin...end= block when there are remaining goals to be
-discharged. 
+discharged.
 
 Within a =begin...end= block, you can abbreviate nested occurrences of
 =begin= and =end= with curly braces:
@@ -905,7 +905,7 @@ end
 #+END_SRC
 In this example, after the =transitivity= tactic is applied, there are
 two goals, =a = ?m_1= and =?m_1 = c=. After the =change=, the two
-goals have been specialized to =a = b= and =b = c=. 
+goals have been specialized to =a = b= and =b = c=.
 
 # TODO(Jeremy): also describe
 #   tactic combinators (like =try=)
@@ -995,7 +995,7 @@ c + b=. The next two examples instead apply associativity to move the
 parenthesis to the right on both sides, and then switch =b= and
 =c=. Notice that the last example specifies that the rewrite should
 take place on the right-hand side by specifying the second argument to
-=add_comm=. 
+=add_comm=.
 
 By default, the =rewrite= tactic affects only the goal. The notation
 =rw t at h= applies the rewrite =t= at hypothesis =h=.
@@ -1031,7 +1031,7 @@ begin
 end
 #+END_SRC
 
-Note that the rewrite tactic can carry out generic calculuations in
+Note that the rewrite tactic can carry out generic calculations in
 any algebraic structure. The following examples involve an arbitrary
 ring and an arbitrary group, respectively.
 #+BEGIN_SRC lean
@@ -1056,7 +1056,7 @@ Whereas =rewrite= is designed as a surgical tool for manipulating a
 goal, the simplifier offers a powerful form of automation. A number of
 identities in Lean's library have been tagged with the =[simp]=
 attribute, and the =simp= tactic uses them to iteratively rewrite
-subterms in an expression. 
+subterms in an expression.
 #+BEGIN_SRC lean
 variables (x y z : ℕ) (p : ℕ → Prop)
 premise   (h : p (x * y))
@@ -1112,7 +1112,7 @@ As with the rewriter, the simplifier behaves appropriately in
 algebraic structures:
 #+BEGIN_SRC lean
 variables {α : Type} [comm_ring α]
- 
+
 example (x y z : α) : (x - x) * y + z = z :=
 begin simp end
 

--- a/05_Tactics.org
+++ b/05_Tactics.org
@@ -1020,7 +1020,7 @@ following example, we use =rw h at t= to rewrite the hypothesis
 #+BEGIN_SRC lean
 universe variable u
 
-definition tuple (α : Type u) (n : ℕ) := { l : list α // list.length l = n }
+def tuple (α : Type u) (n : ℕ) := { l : list α // list.length l = n }
 
 variables {α : Type u} {n : ℕ}
 

--- a/06_Interacting_with_Lean.org
+++ b/06_Interacting_with_Lean.org
@@ -492,7 +492,7 @@ search paths in the =LEAN_PATH= environment variable. You can specify
 subdirectories using periods in the module name: for example, =import
 foo.bar.baz= looks for the file "foo/bar/baz.lean" relative to any of
 the locations listed in the search path. A leading period, as in
-=import .foo.bar=, indicates that the .lean file in question is
+=import .foo.bar=, indicates that the =.lean= file in question is
 specified relative to the current directory. Two leading periods, as
 in =import ..foo.bar=, indicates that the address is relative to the
 parent directory, and so on.

--- a/06_Interacting_with_Lean.org
+++ b/06_Interacting_with_Lean.org
@@ -47,7 +47,7 @@ eval add 3 2
 print add
 
 -- a user-defined function
-definition foo {α : Type} (x : α) : α := x
+def foo {α : Type} (x : α) : α := x
 
 check foo
 check @foo
@@ -573,7 +573,7 @@ new notation.
 #+BEGIN_SRC lean
 notation `[` a `**` b `]` := a * b + 1
 
-definition mul_square (a b : ℕ) := a * a * b * b
+def mul_square (a b : ℕ) := a * a * b * b
 
 infix `<*>`:50 := mul_square
 

--- a/07_Inductive_Types.org
+++ b/07_Inductive_Types.org
@@ -996,7 +996,7 @@ and then reintroduce them.
 #+BEGIN_SRC lean
 universe variable u
 
-definition tuple (α : Type u) (n : ℕ) := { l : list α // list.length l = n }
+def tuple (α : Type u) (n : ℕ) := { l : list α // list.length l = n }
 
 variables {α : Type u} {n : ℕ}
 

--- a/07_Inductive_Types.org
+++ b/07_Inductive_Types.org
@@ -825,7 +825,7 @@ nat.induction_on n
     show 0 + succ n = succ n, from
       calc
         0 + succ n = succ (0 + n) : rfl
-          ... = succ n : by rewrite ih)
+          ... = succ n : by rw ih)
 
 -- END
 end hide
@@ -855,7 +855,7 @@ nat.induction_on k
     show m + n + succ k = m + (n + succ k), from
       calc
         m + n + succ k = succ (m + n + k) : rfl
-          ... = succ (m + (n + k)) : by rewrite ih
+          ... = succ (m + (n + k)) : by rw ih
           ... = m + succ (n + k) : rfl
           ... = m + (n + succ k) : rfl)
 -- END
@@ -877,19 +877,19 @@ nat.induction_on k
     show m + n + succ k = m + (n + succ k), from
       calc
         m + n + succ k = succ (m + n + k) : rfl
-          ... = succ (m + (n + k)) : by rewrite ih
+          ... = succ (m + (n + k)) : by rw ih
           ... = m + succ (n + k) : rfl
           ... = m + (n + succ k) : rfl)
 
 -- BEGIN
 theorem add_comm (m n : nat) : m + n = n + m :=
 nat.induction_on n
-  (show m + 0 = 0 + m, by rewrite nat.zero_add)
+  (show m + 0 = 0 + m, by rw nat.zero_add)
   (take n,
     assume ih : m + n = n + m,
     calc
       m + succ n = succ (m + n) : rfl
-        ... = succ (n + m) : by rewrite ih
+        ... = succ (n + m) : by rw ih
         ... = succ n + m : sorry)
 -- END
 
@@ -910,7 +910,7 @@ nat.induction_on k
     show m + n + succ k = m + (n + succ k), from
       calc
         m + n + succ k = succ (m + n + k) : rfl
-          ... = succ (m + (n + k)) : by rewrite ih
+          ... = succ (m + (n + k)) : by rw ih
           ... = m + succ (n + k) : rfl
           ... = m + (n + succ k) : rfl)
 
@@ -923,7 +923,7 @@ nat.induction_on n
     show succ m + succ n = succ (m + succ n), from
       calc
         succ m + succ n = succ (succ m + n) : rfl
-          ... = succ (succ (m + n)) : by rewrite ih
+          ... = succ (succ (m + n)) : by rw ih
           ... = succ (m + succ n) : rfl)
 -- END
 end hide

--- a/07_Inductive_Types.org
+++ b/07_Inductive_Types.org
@@ -686,7 +686,7 @@ end hide
 The notation ={x : α | p}= is syntactic sugar for =subtype (λ x : α,
 p)=. It is modeled after subset notation in set theory: the idea is
 that ={x : α | p}= denotes the collection of elements of =α= that have
-property =[=.
+property =p=.
 
 ** Defining the Natural Numbers
 

--- a/07_Inductive_Types.org
+++ b/07_Inductive_Types.org
@@ -7,7 +7,7 @@
 :END:
 
 We have seen that Lean's formal foundation includes basic types,
-=Prop, Type.{1}, Type.{2}, ...=, and allows for the formation of
+=Prop, Type 1, Type 2, ...=, and allows for the formation of
 dependent function types, =Π x : α. β=. In the examples, we have also
 made use of additional types like =bool=, =nat=, and =int=, and type
 constructors, like =list=, and product, =×=. In fact, in Lean's library,

--- a/08_Induction_and_Recursion.org
+++ b/08_Induction_and_Recursion.org
@@ -534,7 +534,7 @@ end
 variable {α : Type}
 variable p : α → bool
 
-definition filter : list α → list α
+def filter : list α → list α
 | []       := []
 | (a :: l) :=
   match p a with

--- a/09_Structures_and_Records.org
+++ b/09_Structures_and_Records.org
@@ -281,8 +281,8 @@ structure rgb_val :=
 structure red_green_point (α : Type) extends point α, rgb_val :=
 (no_blue : blue = 0)
 
-definition p   : point nat := {x := 10, y := 10, z := 20}
-definition rgp : red_green_point nat :=
+def p   : point nat := {x := 10, y := 10, z := 20}
+def rgp : red_green_point nat :=
 {p with red := 200, green := 40, blue := 0, no_blue := rfl}
 
 example : rgp^.x   = 10 := rfl

--- a/10_Type_Classes.org
+++ b/10_Type_Classes.org
@@ -252,7 +252,7 @@ instance nat_inhabited : inhabited nat :=
 instance unit_inhabited : inhabited unit :=
 ⟨()⟩
 
-definition default (α : Type) [s : inhabited α] : α :=
+def default (α : Type) [s : inhabited α] : α :=
 @inhabited.value α s
 -- BEGIN
 check default Prop    -- Prop
@@ -284,7 +284,7 @@ instance nat_inhabited : inhabited nat :=
 instance unit_inhabited : inhabited unit :=
 ⟨()⟩
 
-definition default (α : Type) [s : inhabited α] : α :=
+def default (α : Type) [s : inhabited α] : α :=
 @inhabited.value α s
 -- BEGIN
 eval default Prop    -- true
@@ -335,7 +335,7 @@ instance nat_inhabited : inhabited nat :=
 instance unit_inhabited : inhabited unit :=
 ⟨()⟩
 
-definition default (α : Type) [s : inhabited α] : α :=
+def default (α : Type) [s : inhabited α] : α :=
 @inhabited.value α s
 -- BEGIN
 instance prod_inhabited {α β : Type} [inhabited α] [inhabited β]
@@ -364,7 +364,7 @@ instance nat_inhabited : inhabited nat :=
 instance unit_inhabited : inhabited unit :=
 ⟨()⟩
 
-definition default (α : Type) [s : inhabited α] : α :=
+def default (α : Type) [s : inhabited α] : α :=
 @inhabited.value α s
 
 instance prod_inhabited {α β : Type} [inhabited α] [inhabited β]
@@ -404,7 +404,7 @@ instance nat_inhabited : inhabited nat :=
 instance unit_inhabited : inhabited unit :=
 ⟨()⟩
 
-definition default (α : Type) [s : inhabited α] : α :=
+def default (α : Type) [s : inhabited α] : α :=
 @inhabited.value α s
 
 instance prod_inhabited {α β : Type} [inhabited α] [inhabited β]
@@ -469,7 +469,7 @@ the dependent if-then-else expression. It is defined as follows:
 namespace hide
 
 -- BEGIN
-definition dite (c : Prop) [d : decidable c] {α : Type} (t : c → α) (e : ¬ c → α) : α :=
+def dite (c : Prop) [d : decidable c] {α : Type} (t : c → α) (e : ¬ c → α) : α :=
 decidable.rec_on d (λ hnc : ¬ c, e hnc) (λ hc : c, t hc)
 -- END
 end hide
@@ -498,7 +498,7 @@ the natural numbers:
 #+BEGIN_SRC lean
 open nat
 
-definition step (a b x : ℕ) : ℕ :=
+def step (a b x : ℕ) : ℕ :=
 if x < a ∨ x > b then 0 else 1
 
 set_option pp.implicit true


### PR DESCRIPTION
Most of them are typos.
Other than that I fixed some layout issues and also tried to use abbreviations, like `def` instead of `definition`, when available.