### PR TITLE
Remove Outdated Contents

### DIFF
--- a/03_Propositions_and_Proofs.org
+++ b/03_Propositions_and_Proofs.org
@@ -11,9 +11,10 @@ dependent type theory.
 In this chapter, we will explain how mathematical propositions and
 proofs are expressed in the language of dependent type theory, so that
 you can start proving assertions about the objects and notations that
-have been defined. The encoding we use here is specific to the
-standard library; we will discuss proofs in /homotopy type theory/ in
-a later chapter.
+have been defined.
+# The encoding we use here is specific to the
+# standard library; we will discuss proofs in /homotopy type theory/ in
+# a later chapter.
 
 ** Propositions as Types
 

--- a/03_Propositions_and_Proofs.org
+++ b/03_Propositions_and_Proofs.org
@@ -539,13 +539,12 @@ Lean provides another useful syntactic gadget. Given an expression =e=
 of type =foo= (possibly applied to some arguments), the notation
 =e^.bar= is shorthand for =foo.bar e=. This provides a convenient way
 of accessing functions without opening a namespace. For example, the
-following three expressions all mean the same thing:
+following two expressions mean the same thing:
 #+BEGIN_SRC lean
 variable l : list ℕ
 
 check list.head l
 check l^.head
-check l↣head
 #+END_SRC
 As a result, given =h : p ∧ q=, we can write =h^.left= for =and.left h=
 and =h^.right= for =and.right h=. We can therefore rewrite the sample

--- a/10_Type_Classes.org
+++ b/10_Type_Classes.org
@@ -695,7 +695,7 @@ namespaces which are opened later are tried earlier.
 You can change the order that type classes instances are tried by
 assigning them a /priority/. When an instance is declared, it is
 assigned a priority value =std.priority.default=, defined to be 1000
-in module =init.priority= in both the standard and hott libraries. You
+in module =init.core= in the standard library. You
 can assign other priorities when defining an instance, and you can
 later change the priority with the =attribute= command. The following
 example illustrates how this is done:


### PR DESCRIPTION
I removed
1. parts that mention the hott library and
2. the explanation on `↣ `.

I decided to remove 2. because I saw a discussion about a plan to delete the funny arrow notation, but I forgot where it was.
Even though the notation is valid at the moment, I think it is a reasonable suggestion to delete the explanation because the notation `↣ ` is hardly used (actually only a single line used it in the tutorial) and the tutorial currently doesn't tell the command, which is `\pr`, to type it.