### PR TITLE
correct a type mismatch in example related to list types

### DIFF
--- a/dependent_type_theory.rst
+++ b/dependent_type_theory.rst
@@ -749,7 +749,7 @@ Then, given a type ``α``, some elements of ``α``, and some lists of elements o
 
     variable  α : Type
     variable  a : α
-    variables l1 l2 : list α
+    variables l1 l2 : hidden.list α
 
     #check cons α a (nil α)
     #check append α (cons α a (nil α)) l1


### PR DESCRIPTION
I've changed `variables l1 l2 : list α` to `variables l1 l2 : hidden.list α` in this example, because otherwise I get a complaint, as below.  It seems that Lean 3.4.2 finds the standard `list` rather than the one that's made available in the new `hidden` namespace.

``` lean
none of the overloads are applicable
error for hidden.list.append
type mismatch at application
  append α (cons α a (nil α)) l1
term
  l1
has type
  list α
but is expected to have type
  hidden.list α

error for has_append.append
failed to synthesize type class instance for
α : Type,
a : α,
l1 l2 : list α
⊢ has_append Type
Additional information:
/home/joe/theorem-proving-in-lean/ex27.lean:22:7: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
```