### PR TITLE
show needed vars to reader

### DIFF
--- a/tactics.rst
+++ b/tactics.rst
@@ -250,9 +250,9 @@ The ``assumption`` tactic looks through the assumptions in context of the curren
 
 .. code-block:: lean
 
+    -- BEGIN
     variables x y z w : ℕ
 
-    -- BEGIN
     example (h₁ : x = y) (h₂ : y = z) (h₃ : z = w) : x = w :=
     begin
       apply eq.trans h₁,


### PR DESCRIPTION
Without the variables shown to the reader a lot of errors appear, like `unknown identifier 'x'`.

The line introducing them is there is the source, but position of `-- BEGIN` meant it's not shown in the rendered HTML.