### PR TITLE
make the variables show up in HTML

### DIFF
--- a/tactics.rst
+++ b/tactics.rst
@@ -1197,9 +1197,9 @@ As with ``rw``, you can use the keyword ``at`` to simplify a hypothesis:
 
 .. code-block:: lean
 
+    -- BEGIN
     variables (x y z : ℕ) (p : ℕ → Prop)
 
-    -- BEGIN
     example (h : p ((x + 0) * (0 + y * 1 + z * 0))) : 
       p (x * y) :=
     by { simp at h, assumption }


### PR DESCRIPTION
The variables were defined earlier but then an example that didn't use them was discussed.  Suggestion to redefine them in context so code can be straightforwardly run after copy-and-paste.