### PR TITLE
definition doesn't need to be repeated

### DIFF
--- a/tactics.rst
+++ b/tactics.rst
@@ -1336,10 +1336,9 @@ Then for any list ``xs``, ``reverse (mk_symm xs)`` is equal to ``mk_symm xs``, w
     open list
     universe u  
     variables {α : Type} (x y z : α) (xs ys zs : list α)
-
-    -- BEGIN
     def mk_symm (xs : list α) := xs ++ reverse xs
 
+    -- BEGIN
     theorem reverse_mk_symm (xs : list α) : 
       reverse (mk_symm xs) = mk_symm xs :=
     by { unfold mk_symm, simp }
@@ -1353,10 +1352,9 @@ Or even more simply,
     open list
     universe u  
     variables {α : Type} (x y z : α) (xs ys zs : list α)
-
-    -- BEGIN
     def mk_symm (xs : list α) := xs ++ reverse xs
 
+    -- BEGIN
     theorem reverse_mk_symm (xs : list α) : 
       reverse (mk_symm xs) = mk_symm xs :=
     by simp [mk_symm]


### PR DESCRIPTION
The definition of `mk_symm` doesn't need to be repeated here (note that none of the variables and so on are repeated).