### PR TITLE
minor wording change: we see it now, will *discuss* further later on

### DIFF
--- a/tactics.rst
+++ b/tactics.rst
@@ -1468,7 +1468,7 @@ The attribute can also be applied any time after the theorem is declared:
     by simp at h; assumption
     -- END
 
-Once the attribute is applied, however, there is no way to remove it; it persists in any file that imports the one where the attribute is assigned. As we will see in :numref:`attributes`, one can limit the scope of an attribute to the current file or section using the ``local attribute`` command:
+Once the attribute is applied, however, there is no way to remove it; it persists in any file that imports the one where the attribute is assigned. As we will discuss further in :numref:`attributes`, one can limit the scope of an attribute to the current file or section using the ``local attribute`` command:
 
 .. code-block:: lean
 


### PR DESCRIPTION
This is a one-line wording change.  Maybe subjective, but it seems to read better this way, since an example is already given in the current section (but theory appears later).