### PR TITLE
wording to distinguish effect of omit

### DIFF
--- a/interacting_with_lean.rst
+++ b/interacting_with_lean.rst
@@ -84,7 +84,7 @@ Note that double does *not* have ``y`` as argument. Variables are only included 
       #check @baz
     end
 
-The ``omit`` command simply undoes the effect of the ``include``; it does not prevent the arguments from being included automatically in subsequent theorems that mention them. The scope of the ``include`` statement can also be delimited by enclosing it in a section.
+The ``omit`` command simply undoes the effect of the ``include``, however, it does not prevent the arguments from being included automatically in subsequent theorems that mention them. The scope of the ``include`` statement can also be delimited by enclosing it in a section.
 
 .. code-block:: lean
 


### PR DESCRIPTION
Minor wording change to clarify what it means to **undo** "the effect of include".

Original:

> The omit command simply undoes the effect of the include; it does not prevent the arguments from being included automatically in subsequent theorems that mention them. 

This looked to me as if the text after the semicolon explains the text before the semicolon, but that's not the case.  The text after the semicolon is a caveat that circumscribes the description before the semicolon.