### PR TITLE
fix typo in inductive type tutorial

### DIFF
--- a/inductive_types.rst
+++ b/inductive_types.rst
@@ -408,7 +408,7 @@ Notice that the product type depends on parameters ``α β : Type`` which are ar
 
     end hidden
 
-As a result, the argument ``α`` to ``inl`` and the argument ``β`` to ``inr`` are left implicit.
+As a result, the argument ``β`` to ``inl`` and the argument ``α`` to ``inr`` are left implicit.
 
 In the section after next we will see what happens when the constructor of an inductive type takes arguments from the inductive type itself. What characterizes the examples we consider in this section is that this is not the case: each constructor relies only on previously specified types.
 


### PR DESCRIPTION
I am very new to lean, so I hope this is right. The usage of α and β seem to be swapped at this particular line.
Very good documentation btw, I've learned a lot!