### PR TITLE
move namespace within exported code so that the code works

### DIFF
--- a/induction_and_recursion.rst
+++ b/induction_and_recursion.rst
@@ -731,9 +731,9 @@ The constructors, ``even_zero``, ``even_succ``, and ``odd_succ`` provide positiv
     with odd : ℕ → Prop
     | odd_succ : ∀ n, even n → odd (n + 1)
 
+    -- BEGIN
     open even odd
 
-    -- BEGIN
     theorem not_odd_zero : ¬ odd 0.
 
     mutual theorem even_of_odd_succ, odd_of_even_succ


### PR DESCRIPTION
An alternative to this fix -- which just uses the code that was originally intended -- would be to make an explicit reference into the namespaces.  Either way the behaviour is complicated enough that it might be worth an additional sentence to say what's going on.

``` lean
mutual theorem even_of_odd_succ, odd_of_even_succ
with even_of_odd_succ : ∀ n, odd (n + 1) → even n
| _ (odd.odd_succ n h) := h
with odd_of_even_succ : ∀ n, even (n + 1) → odd n
| _ (even.even_succ n h) := h
```