### PR TITLE
tactics.rst: fix example

### DIFF
--- a/tactics.rst
+++ b/tactics.rst
@@ -1254,9 +1254,9 @@ As with ``rewrite``, you can send ``simp`` a list of facts to use, including gen
 
     def f (m n : ℕ) : ℕ := m + n + m
 
-    example {m n : ℕ} (h : n = 1) (h' : 0 = m) : (f m n) * m = m :=
+    example {m n : ℕ} (h : n = 1) (h' : 0 = m) : (f m n) = n :=
     by simp [h, h'.symm, f]
-
+    
 A common idiom is to simplify a goal using local hypotheses:
 
 .. code-block:: lean


### PR DESCRIPTION
The example as shown in the book:

    example {m n : ℕ} (h : n = 1) (h' : 0 = m) : (f m n) * m = m := by simp [h, h'.symm, f]

doesn't actually require all three items passed to `simp`. It only requires two:

    example {m n : ℕ} (h : n = 1) (h' : 0 = m) : (f m n) * m = m := by simp [h, h'.symm]

These two work as well:

    example {m n : ℕ} (h : n = 1) (h' : 0 = m) : (f m n) * m = m := by simp [f, h'.symm]

If we change the goal as follows, all three appear to be required:

    example {m n : ℕ} (h : n = 1) (h' : 0 = m) : (f m n) = n := by simp [h, h'.symm, f]