### PR TITLE
Say in README how to install mathlib for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The call to `make install-deps` is only required the first time, and only if you
 # How to test the Lean code snippets
 
 ```
+leanproject new
 make leantest
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The call to `make install-deps` is only required the first time, and only if you
 # How to test the Lean code snippets
 
 ```
-leanproject new
+leanproject global-install
 make leantest
 ```
 


### PR DESCRIPTION
The tests fail if mathlib is absent, and this seems to be the easiest way to ensure that mathlib is present.