### PR TITLE
adding support to build PDFs for e-readers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.olean
 /_target
 /leanpkg.path
+/__pycache__
+/_build

--- a/README.md
+++ b/README.md
@@ -11,12 +11,19 @@ leanproject get git@github.com:leanprover/theorem_proving_in_lean.git
 ```
 to clone the repository and install the `mathlib` library. 
 
-The build requires python 3 (install `python3-venv` on ubuntu).
+The build requires python 3, xelatex, latexmk and some OTF fonts.
 
+On Ubuntu, you may install these dependencies by running
+
+```bash
+sudo apt install python3-venv texlive-xetex latexmk fonts-freefont-otf
 ```
+
+```bash
 make install-deps
 make html
 make latexpdf
+PAPER_SIZE=a5paper make latexpdf  # for e-readers
 ```
 
 The call to `make install-deps` is only required the first time, and only if you want to use the bundled version of Sphinx and Pygments with improved syntax highlighting for Lean.

--- a/conf.py
+++ b/conf.py
@@ -147,7 +147,7 @@ latex_additional_files = ['unixode.sty']
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
-    # 'papersize': 'letterpaper',
+    'papersize': os.getenv('PAPER_SIZE') or 'letterpaper',
 
     # The font size ('10pt', '11pt' or '12pt').
     #

--- a/lean_sphinx.py
+++ b/lean_sphinx.py
@@ -1,7 +1,6 @@
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.builders import Builder
-from sphinx.directives import CodeBlock
 from sphinx.errors import SphinxError
 import os, os.path, fnmatch, subprocess
 import codecs


### PR DESCRIPTION
Also updated some instructions in README based on my experience and fixed a breakage in `lean_sphinx.py`

The cover page on A5 is not perfect (authors get pushed beyond the boundary), otherwise it looks OK to me.