### PR TITLE
Adding import algebra.group_power to exercise 4.6.4

### DIFF
--- a/quantifiers_and_equality.rst
+++ b/quantifiers_and_equality.rst
@@ -842,6 +842,7 @@ Exercises
    .. code-block:: lean
 
        import data.nat.basic
+       import algebra.group_power
 
        #check even
 


### PR DESCRIPTION
nat.pow was removed from core about a year ago, and it is necessary to complete this exercise﻿
