### PR TITLE
Update to leanprover-community/mathlib@feb165c

### DIFF
--- a/axioms_and_computation.rst
+++ b/axioms_and_computation.rst
@@ -117,7 +117,7 @@ Suppose that for ``α : Type`` we define the ``set α := α → Prop`` to denote
     variable {α : Type*}
 
     definition mem (x : α) (a : set α) := a x
-    notation e ∈ a := mem e a
+    notation (name := mem) e ∈ a := mem e a
 
     theorem setext {a b : set α} (h : ∀ x, x ∈ a ↔ x ∈ b) : a = b :=
     funext (assume x, propext (h x))
@@ -147,10 +147,10 @@ We can then proceed to define the empty set and set intersection, for example, a
 
     -- BEGIN
     definition empty : set α := λ x, false
-    local notation `∅` := empty
+    local notation (name := empty) `∅` := empty
 
     definition inter (a b : set α) : set α := λ x, x ∈ a ∧ x ∈ b
-    notation a ∩ b := inter a b
+    notation (name := inter) a ∩ b := inter a b
 
     theorem inter_self (a : set α) : a ∩ a = a :=
     setext (assume x, and_self _)
@@ -302,7 +302,7 @@ To support this common use case, the standard library defines the notion of a *s
     (r : α → α → Prop) (iseqv : equivalence r)
 
     namespace setoid
-    infix `≈` := setoid.r
+    infix (name := r) `≈` := setoid.r
 
     variable {α : Type*}
     variable [s : setoid α]
@@ -351,7 +351,7 @@ Recall that in the standard library, ``α × β`` represents the Cartesian produ
     private definition eqv {α : Type*} (p₁ p₂ : α × α) : Prop :=
     (p₁.1 = p₂.1 ∧ p₁.2 = p₂.2) ∨ (p₁.1 = p₂.2 ∧ p₁.2 = p₂.1)
 
-    infix `~` := eqv
+    infix (name := eqv) `~`:50 := eqv
 
 The next step is to prove that ``eqv`` is in fact an equivalence relation, which is to say, it is reflexive, symmetric and transitive. We can prove these three facts in a convenient and readable way by using dependent pattern matching to perform case-analysis and break the hypotheses into pieces that are then reassembled to produce the conclusion.
 
@@ -360,7 +360,7 @@ The next step is to prove that ``eqv`` is in fact an equivalence relation, which
     private definition eqv {α : Type*} (p₁ p₂ : α × α) : Prop :=
     (p₁.1 = p₂.1 ∧ p₁.2 = p₂.2) ∨ (p₁.1 = p₂.2 ∧ p₁.2 = p₂.1)
 
-    local infix `~` := eqv
+    local infix (name := eqv) `~`:50 := eqv
 
     -- BEGIN
     open or
@@ -406,7 +406,7 @@ Now that we have proved that ``eqv`` is an equivalence relation, we can construc
     private definition eqv {α : Type*} (p₁ p₂ : α × α) : Prop :=
     (p₁.1 = p₂.1 ∧ p₁.2 = p₂.2) ∨ (p₁.1 = p₂.2 ∧ p₁.2 = p₂.1)
 
-    local infix `~` := eqv
+    local infix (name := eqv) `~`:50 := eqv
 
     open or
 
@@ -454,7 +454,7 @@ We can easily prove that ``{a₁, a₂} = {a₂, a₁}`` using ``quot.sound``, s
     private definition eqv {α : Type*} (p₁ p₂ : α × α) : Prop :=
     (p₁.1 = p₂.1 ∧ p₁.2 = p₂.2) ∨ (p₁.1 = p₂.2 ∧ p₁.2 = p₂.1)
 
-    local infix `~` := eqv
+    local infix (name := eqv) `~`:50 := eqv
 
     open or
 
@@ -504,7 +504,7 @@ To complete the example, given ``a : α`` and ``u : uprod α``, we define the pr
     private definition eqv {α : Type*} (p₁ p₂ : α × α) : Prop :=
     (p₁.1 = p₂.1 ∧ p₁.2 = p₂.2) ∨ (p₁.1 = p₂.2 ∧ p₁.2 = p₂.1)
 
-    local infix `~` := eqv
+    local infix (name := eqv) `~`:50 := eqv
 
     open or
 
@@ -569,7 +569,7 @@ To complete the example, given ``a : α`` and ``u : uprod α``, we define the pr
     def mem {α : Type*} (a : α) (u : uprod α) : Prop :=
     quot.lift_on u (λ p, mem_fn a p) (λ p₁ p₂ e, mem_respects a e)
 
-    local infix `∈` := mem
+    local infix (name := mem) `∈` := mem
 
     theorem mem_mk_left {α : Type*} (a b : α) : a ∈ {a, b} :=
     inl rfl

--- a/induction_and_recursion.rst
+++ b/induction_and_recursion.rst
@@ -362,7 +362,7 @@ As we saw in the last section, the terms ``t₁, ..., tₙ`` can make use of any
     | m zero     := m
     | m (succ n) := succ (add m n)
 
-    local infix ` + ` := add
+    local infix (name := add) ` + ` := add
 
     theorem add_zero (m : nat) : m + zero = m := rfl
     theorem add_succ (m n : nat) : m + succ n = succ (m + n) := rfl
@@ -397,7 +397,7 @@ The example above shows that the defining equations for ``add`` hold definitiona
     | m zero     := m
     | m (succ n) := succ (add m n)
 
-    local infix ` + ` := add
+    local infix (name := add) ` + ` := add
 
     -- BEGIN
     theorem zero_add : ∀ n, zero + n = n
@@ -428,7 +428,7 @@ In fact, because in this case the defining equations hold definitionally, we can
     | m zero     := m
     | m (succ n) := succ (add m n)
 
-    local infix ` + ` := add
+    local infix (name := add) ` + ` := add
 
     -- BEGIN
     theorem zero_add : ∀ n, zero + n = n
@@ -590,7 +590,7 @@ Here is essentially the definition of division on the natural numbers that is fo
     open nat
 
     def div_rec_lemma {x y : ℕ} : 0 < y ∧ y ≤ x → x - y < x :=
-    λ h, sub_lt (lt_of_lt_of_le h.left h.right) h.left
+    λ h, nat.sub_lt (lt_of_lt_of_le h.left h.right) h.left
 
     def div.F (x : ℕ) (f : Π x₁, x₁ < x → ℕ → ℕ) (y : ℕ) : ℕ :=
     if h : 0 < y ∧ y ≤ x then
@@ -617,7 +617,7 @@ The equation compiler is designed to make definitions like this more convenient.
     | x y :=
       if h : 0 < y ∧ y ≤ x then
         have x - y < x,
-          from sub_lt (lt_of_lt_of_le h.left h.right) h.left,
+          from nat.sub_lt (lt_of_lt_of_le h.left h.right) h.left,
         div (x - y) y + 1
       else
         0
@@ -638,7 +638,7 @@ The defining equation for ``div`` does *not* hold definitionally, but the equati
     | x y :=
       if h : 0 < y ∧ y ≤ x then
         have x - y < x,
-          from sub_lt (lt_of_lt_of_le h.left h.right) h.left,
+          from nat.sub_lt (lt_of_lt_of_le h.left h.right) h.left,
         div (x - y) y + 1
       else
         0
@@ -797,7 +797,7 @@ All the examples of pattern matching we considered in :numref:`pattern_matching`
     | cons   : Π {n}, α → vector n → vector (n+1)
 
     namespace vector
-    local notation h :: t := cons h t
+    local notation (name := cons) h :: t := cons h t
 
     #check @vector.cases_on
     -- Π {α : Type*}
@@ -824,7 +824,7 @@ One solution is to define an auxiliary function:
     | cons   : Π {n}, α → vector n → vector (n+1)
 
     namespace vector
-    local notation h :: t := cons h t
+    local notation (name := cons) h :: t := cons h t
 
     -- BEGIN
     def tail_aux {α : Type*} {n m : ℕ} (v : vector α m) :
@@ -857,7 +857,7 @@ The ``tail`` function is, however, easy to define using recursive equations, and
     | cons   : Π {n}, α → vector n → vector (n+1)
 
     namespace vector
-    local notation h :: t := cons h t
+    local notation (name := cons) h :: t := cons h t
 
     -- BEGIN
     def head {α : Type*} : Π {n}, vector α (n+1) → α
@@ -894,7 +894,7 @@ Note that we can omit recursive equations for "unreachable" cases such as ``head
     | cons   : Π {n}, α → vector n → vector (n+1)
 
     namespace vector
-    local notation h :: t := cons h t
+    local notation (name := cons) h :: t := cons h t
 
     def map {α β γ : Type*} (f : α → β → γ)
             : Π {n : nat}, vector α n → vector β n → vector γ n
@@ -946,7 +946,7 @@ Inaccessible terms can be used to clarify and control definitions that make use 
     | cons   : Π {n}, α → vector n → vector (n+1)
 
     namespace vector
-    local notation h :: t := cons h t
+    local notation (name := cons) h :: t := cons h t
 
     variable {α : Type u}
 
@@ -970,7 +970,7 @@ But, in fact, a case split is not required on the first argument; the ``cases_on
     | cons   : Π {n}, α → vector n → vector (n+1)
 
     namespace vector
-    local notation h :: t := cons h t
+    local notation (name := cons) h :: t := cons h t
 
     variable {α : Type u}
 
@@ -995,7 +995,7 @@ Using explicit inaccessible terms makes it even clearer what is going on.
     | cons   : Π {n}, α → vector n → vector (n+1)
 
     namespace vector
-    local notation h :: t := cons h t
+    local notation (name := cons) h :: t := cons h t
 
     variable {α : Type u}
 

--- a/inductive_types.rst
+++ b/inductive_types.rst
@@ -1016,7 +1016,7 @@ Notice that ``cases`` can be used to produce data as well as prove propositions.
     example : f 0 = 3 := rfl
     example : f 5 = 7 := rfl
 
-Once again, cases will revert, split, and then reintroduce depedencies in the context.
+Once again, cases will revert, split, and then reintroduce dependencies in the context.
 
 .. code-block:: lean
 

--- a/inductive_types.rst
+++ b/inductive_types.rst
@@ -855,12 +855,12 @@ Let us consider some more examples of inductively defined types. For any type, `
 
     variable {α : Type*}
 
-    notation h :: t  := cons h t
+    notation (name := cons) h :: t  := cons h t
 
     def append (s t : list α) : list α :=
     list.rec t (λ x l u, x::u) s
 
-    notation s ++ t := append s t
+    notation (name := append) s ++ t := append s t
 
     theorem nil_append (t : list α) : nil ++ t = t := rfl
 
@@ -886,7 +886,7 @@ Lean allows us to define iterative notation for lists:
 
     namespace list
 
-    notation `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
+    notation (name := list)  `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
 
     section
     open nat
@@ -913,16 +913,16 @@ As an exercise, prove the following:
 
     namespace list
 
-    notation `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
+    notation (name := list)  `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
 
     variable {α : Type*}
 
-    notation h :: t  := cons h t
+    notation (name := cons) h :: t  := cons h t
 
     def append (s t : list α) : list α :=
     list.rec_on s t (λ x l u, x::u)
 
-    notation s ++ t := append s t
+    notation (name := append) s ++ t := append s t
 
     theorem nil_append (t : list α) : nil ++ t = t := rfl
 
@@ -1215,7 +1215,7 @@ As with ``cases``, we can use the ``case`` tactic instead to identify one case a
     begin
       induction n,
       case zero : { refl },
-      case succ : n ih { rw [add_succ, ih] }
+      case succ : n ih { rw [add_succ, add_succ, ih] }
     end
 
     theorem add_comm (m n : ℕ) : m + n = n + m :=

--- a/interacting_with_lean.rst
+++ b/interacting_with_lean.rst
@@ -210,7 +210,7 @@ Although the names of theorems and definitions have to be unique, the aliases th
 
 .. code-block:: lean
 
-    import algebra.ordered_ring
+    import algebra.group.basic
 
     #check add_sub_cancel
     #check nat.add_sub_cancel
@@ -495,7 +495,7 @@ Lean's parser is extensible, which is to say, we can define new notation.
 
     def mul_square (a b : ℕ) := a * a * b * b
 
-    infix `<*>`:50 := mul_square
+    infix (name := mul_square) `<*>`:50 := mul_square
 
     #reduce [2 ** 3]
     #reduce 2 <*> 3
@@ -554,7 +554,7 @@ The possibility of declaring parameters in a section also makes it possible to d
 
     definition mod_equiv := (m ∣ b - a)
 
-    local infix ≡ := mod_equiv
+    local infix ` ≡ `:50 := mod_equiv
 
     theorem mod_refl : a ≡ a :=
     show m ∣ a - a, by simp
@@ -568,7 +568,7 @@ The possibility of declaring parameters in a section also makes it possible to d
     begin
       cases h₁ with d hd, cases h₂ with e he,
       apply dvd_intro (d + e),
-      simp [mul_add, eq.symm hd, eq.symm he, sub_eq_add_neg]
+      simp [mul_add, eq.symm hd, eq.symm he],
     end
     end mod_m
 
@@ -657,7 +657,7 @@ We will discuss inductive types, structures, classes, instances in the next four
 
 .. code-block:: lean
 
-    import algebra.ring
+    import algebra.ring.basic
 
     #print notation
     #print notation + * -
@@ -807,7 +807,7 @@ Sometimes, to disambiguate the name of theorem or better convey the intended ref
 
 .. code-block:: lean
 
-    import algebra.ordered_ring
+    import algebra.order.monoid.lemmas
 
     #check @nat.lt_of_succ_le
     #check @lt_of_not_ge
@@ -818,7 +818,7 @@ Sometimes the word "left" or "right" is helpful to describe variants of a theore
 
 .. code-block:: lean
 
-    import algebra.ordered_ring
+    import algebra.order.monoid.lemmas
 
     #check @add_le_add_left
     #check @add_le_add_right
@@ -827,7 +827,7 @@ We can also use the word "self" to indicate a repeated argument:
 
 .. code-block:: lean
 
-    import algebra.group
+    import algebra.group.basic
 
     #check mul_inv_self
     #check neg_add_self

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "theorem_proving_in_lean"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.24.0"
+lean_version = "leanprover-community/lean:3.50.3"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "fac0f253201cf36ef3a2b67db06e70f16ee9a53d"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "feb165c980c918bb296fede8c3b21dbb4b85bb56"}

--- a/quantifiers_and_equality.rst
+++ b/quantifiers_and_equality.rst
@@ -570,7 +570,7 @@ This is essentially just alternative notation for the ``match`` construct above.
 
 We will see in :numref:`Chapter %s <induction_and_recursion>` that all these variations are instances of a more general pattern-matching construct.
 
-In the following example, we define ``even a`` as ``∃ b, a = 2*b``, and then we show that the sum of two even numbers is an even number.
+In the following example, we define ``is_even a`` as ``∃ b, a = 2*b``, and then we show that the sum of two even numbers is an even number.
 
 .. code-block:: lean
 

--- a/quantifiers_and_equality.rst
+++ b/quantifiers_and_equality.rst
@@ -840,7 +840,7 @@ Exercises
 
    .. code-block:: lean
 
-       import data.nat.basic
+       import data.nat.parity
 
        #check even
 


### PR DESCRIPTION
Update all code snippets to make sure they run without error nor warning on https://github.com/leanprover-community/mathlib/commit/feb165c980c918bb296fede8c3b21dbb4b85bb56, which is the commit the Lean web editor runs on. Exceptions are:
* Code snippets that claim to present how things are defined in core Lean. Since Kyle's notation rehaul, those are broken as we need to name the notation to avoid a clash. I've decided nobody would try to run those snippets anyway.
* `u` and `v` from the Diaconescu's theorem section. Lean complains they are computable, which is of course nonsense (unless it's because they are Props?), and certainly goes against the pedagogical point of the section.

The updated imports are not minimal, but instead sensible ones that we want people to know. I paid attention to having a single import per snippet.

The update is not to bleeding-edge mathlib, so there's still the risk that people will try running the snippets on their newer mathlib install. However, not much has changed since January, and I haven't personally spotted anything that would need further changes.

Closes #110
Closes #117
Closes #118